### PR TITLE
Release v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # IteratorStream [![Build Status](https://secure.travis-ci.org/brianloveswords/iterator-stream.png)](http://travis-ci.org/brianloveswords/iterator-stream)
+## v0.4.0
 
 An adapter for turning an iterator into a streaming iterator.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Note that it doesn't have to call `next()`! See `method` below.
 
 #### Application Order
 ```
-transform -> takeWhile -> filter -> format
+transform → takeWhile → filter → format
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Note that it doesn't have to call `next()`! See `method` below.
 - `transform`: A method to run on every (non-null) value coming from the
   iterator. Defaults to `function (x) { return x; }`
 
+#### Application Order
+```
+transform -> takeWhile -> filter -> format
+```
+
 ### Example
 
 ```js

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note that it doesn't have to call `next()`! See `method` below.
 
 ### Options
 - `separator`: A string added to the end of each computation before
-  emitting. Defaults to `\n'`. Pass `null` to disable.
+  emitting. 
 - `format`: Can be a method or a format string that will be passed to
   `util.format`. Defaults to `'%s'`. If given a function, it will be
   called like `formatFn(value)` where value is the raw output of the
@@ -40,7 +40,7 @@ Note that it doesn't have to call `next()`! See `method` below.
   computed. If the resulting computations are small, this could be
   inefficient. If you pass a `bufferSize`, it will buffer **at least**
   that many bytes before emitting a data event.
-- `condition`: An optional condition function to run against the output
+- `takeWhile`: An optional condition function to run against the output
   of every computation. If this check fails, no more data will be send
   and an `end` event will be emitted. Useful for infinite iterators.
 - `iterations`: Maximum number of iterations to go through before

--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ Note that it doesn't have to call `next()`! See `method` below.
   of every computation. If this check fails, no more data will be send
   and an `end` event will be emitted. Useful for infinite iterators.
 - `iterations`: Maximum number of iterations to go through before
-  `end`ing. Defaults to Infinity.
+  `end`ing.
+- `take`: How many items to take before calling it quits. This is
+  different from `iterations` only when a `filter` is passed – `take` is
+  counted post-filter, iterations is pre-filter.
 - `method`: Name of the method to call over and over again. Defaults to
   `"next"`
 - `transform`: A method to run on every (non-null) value coming from the
-  iterator. Defaults to `function (x) { return x; }`
+  iterator. Defaults to `function (x) { return x }`
 
 #### Application Order
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# IteratorStream [![Build Status](https://secure.travis-ci.org/brianloveswords/iterator-stream.png)](http://travis-ci.org/brianloveswords/iterator-stream)
-## v0.4.0
+# IteratorStream v0.4.0 [![Build Status](https://secure.travis-ci.org/brianloveswords/iterator-stream.png)](http://travis-ci.org/brianloveswords/iterator-stream)
 
 An adapter for turning an iterator into a streaming iterator.
 

--- a/index.js
+++ b/index.js
@@ -13,9 +13,7 @@ function IterStream(iter, options) {
   this.transform = options.transform || identity;
   this.filter = options.filter || alwaysTrue;
   this.take = options.take || Infinity;
-  this.separator = typeof options.separator === 'undefined'
-    ? '\n'
-    : (options.separator || '');
+  this.separator = options.separator || '';
   if (typeof this.format === 'function')
     this.formatOutput = this.format;
   this.iter = iter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iterator-stream",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "An adapter for making any iterator streaming",
   "main": "index.js",
   "directories": {

--- a/test/iterstream.test.js
+++ b/test/iterstream.test.js
@@ -94,13 +94,24 @@ test('method option', function (t) {
 
 test('transform option', function (t) {
   var str = StreamString();
-  iterstream(random(), {
-    transform: function(v) { return 'hi' },
+  iterstream(natural(), {
+    transform: function (v) { return 'hi' },
     iterations: 3,
-    method: 'random',
     separator: '',
   }).pipe(str).once('end', function () {
     t.same(str.value, 'hihihi');
+    t.end();
+  });
+});
+
+test('filter option', function (t) {
+  var str = StreamString();
+  iterstream(natural(), {
+    filter: function (v) { return v % 2 == 0 },
+    iterations: 4,
+    separator: '',
+  }).pipe(str).once('end', function () {
+    t.same(str.value, '0246');
     t.end();
   });
 });

--- a/test/iterstream.test.js
+++ b/test/iterstream.test.js
@@ -50,10 +50,10 @@ test('record separator', function (t) {
   });
 });
 
-test('additional condition', function (t) {
+test('takeWhile', function (t) {
   var str = StreamString();
   iterstream(letter(), {
-    condition: function (value) { return value < 'D'; }
+    takeWhile: function (value) { return value < 'D'; }
   }).pipe(str).once('end', function () {
     t.same(str.value, 'A\nB\nC\n');
     t.end();
@@ -104,14 +104,26 @@ test('transform option', function (t) {
   });
 });
 
+
 test('filter option', function (t) {
   var str = StreamString();
   iterstream(natural(), {
     filter: function (v) { return v % 2 == 0 },
-    iterations: 4,
+    takeWhile: function (v) { return v <= 10 },
     separator: '',
   }).pipe(str).once('end', function () {
-    t.same(str.value, '0246');
+    t.same(str.value, '0246810');
+    t.end();
+  });
+});
+
+test('take option', function (t) {
+  var str = StreamString();
+  iterstream(natural(), {
+    take: 5,
+    separator: '',
+  }).pipe(str).once('end', function () {
+    t.same(str.value, '01234');
     t.end();
   });
 });

--- a/test/iterstream.test.js
+++ b/test/iterstream.test.js
@@ -43,7 +43,7 @@ test('record separator', function (t) {
     format: '%s',
     separator: '.'
   }).pipe(str).once('end', function () {
-    t.same(str.value, 'A.B.C.D.E.F.G.H.I.J.K.L.M.N.O.P.Q.R.S.T.U.V.W.X.Y.Z.');
+    t.same(str.value, 'A.B.C.D.E.F.G.H.I.J.K.L.M.N.O.P.Q.R.S.T.U.V.W.X.Y.Z');
     t.end();
   });
 });

--- a/test/iterstream.test.js
+++ b/test/iterstream.test.js
@@ -11,7 +11,7 @@ var random = iterators.random;
 
 test('testing regular ol ABCs', function (t) {
   var str = StreamString();
-  iterstream(letter(), { separator: null }).pipe(str).once('end', function () {
+  iterstream(letter()).pipe(str).once('end', function () {
     t.same(str.value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
     t.end();
   });
@@ -21,7 +21,6 @@ test('formatting with a string', function (t) {
   var str = StreamString();
   iterstream(letter(), {
     format: '%s|',
-    separator: null
   }).pipe(str).once('end', function () {
     t.same(str.value, 'A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z|');
     t.end();
@@ -32,7 +31,6 @@ test('formatting with a method', function (t) {
   var str = StreamString();
   iterstream(letter(), {
     format: function (l) { return l.toLowerCase(); },
-    separator: null,
   }).pipe(str).once('end', function () {
     t.same(str.value, 'abcdefghijklmnopqrstuvwxyz');
     t.end();
@@ -55,7 +53,7 @@ test('takeWhile', function (t) {
   iterstream(letter(), {
     takeWhile: function (value) { return value < 'D'; }
   }).pipe(str).once('end', function () {
-    t.same(str.value, 'A\nB\nC\n');
+    t.same(str.value, 'ABC');
     t.end();
   });
 });
@@ -66,7 +64,7 @@ test('buffering stuff', function (t) {
     bufferSize: 8192
   }).pipe(str).once('end', function () {
     t.ok(str.events[0].size >= 8192, 'should have buffered the send');
-    t.same(str.value.indexOf('1.3069892237633987e+308\n'), 32907, 'should have the last event');
+    t.ok(str.value.indexOf('1.3069892237633987e+308') > -1, 'should have the last event');
     t.end();
   });
 });
@@ -97,7 +95,6 @@ test('transform option', function (t) {
   iterstream(natural(), {
     transform: function (v) { return 'hi' },
     iterations: 3,
-    separator: '',
   }).pipe(str).once('end', function () {
     t.same(str.value, 'hihihi');
     t.end();
@@ -110,7 +107,6 @@ test('filter option', function (t) {
   iterstream(natural(), {
     filter: function (v) { return v % 2 == 0 },
     takeWhile: function (v) { return v <= 10 },
-    separator: '',
   }).pipe(str).once('end', function () {
     t.same(str.value, '0246810');
     t.end();
@@ -121,7 +117,6 @@ test('take option', function (t) {
   var str = StreamString();
   iterstream(natural(), {
     take: 5,
-    separator: '',
   }).pipe(str).once('end', function () {
     t.same(str.value, '01234');
     t.end();


### PR DESCRIPTION
# Changelog v0.4.0
- [ **incompatible** ] No more default separator.
- [ **incompatible** ] Last `separator` is omitted.
- [ **feature** ] Implement `filter` option
- [ **feature** ] Implement `take` option
- [ **notice** ] `condition` is aliased to `takeWhile`
